### PR TITLE
Migrate from OpenCV 3 to OpenCV 4

### DIFF
--- a/gridmap_2d/include/gridmap_2d/GridMap2D.h
+++ b/gridmap_2d/include/gridmap_2d/GridMap2D.h
@@ -129,7 +129,7 @@ public:
   /// @return the cv::Mat binary image.
   const cv::Mat& binaryMap() const {return m_binaryMap;}
   /// @return the size of the cv::Mat binary image. Note that x/y are swapped wrt. height/width
-  inline const CvSize size() const {return m_binaryMap.size();}
+  inline const cv::Size size() const {return m_binaryMap.size();}
 
   const static uchar FREE = 255;  ///< char value for "free": 255
   const static uchar OCCUPIED = 0; ///< char value for "free": 0

--- a/gridmap_2d/src/GridMap2D.cpp
+++ b/gridmap_2d/src/GridMap2D.cpp
@@ -59,7 +59,7 @@ GridMap2D::~GridMap2D() {
 }
 
 void GridMap2D::updateDistanceMap(){
-  cv::distanceTransform(m_binaryMap, m_distMap, CV_DIST_L2, CV_DIST_MASK_PRECISE);
+  cv::distanceTransform(m_binaryMap, m_distMap, cv::DistanceTypes::DIST_L2, cv::DistanceTransformMasks::DIST_MASK_PRECISE);
   // distance map now contains distance in meters:
   m_distMap = m_distMap * m_mapInfo.resolution;
 }
@@ -125,7 +125,7 @@ void GridMap2D::setMap(const cv::Mat& binaryMap){
   m_binaryMap = binaryMap.clone();
   m_distMap = cv::Mat(m_binaryMap.size(), CV_32FC1);
 
-  cv::distanceTransform(m_binaryMap, m_distMap, CV_DIST_L2, CV_DIST_MASK_PRECISE);
+  cv::distanceTransform(m_binaryMap, m_distMap, cv::DistanceTypes::DIST_L2, cv::DistanceTransformMasks::DIST_MASK_PRECISE);
   // distance map now contains distance in meters:
   m_distMap = m_distMap * m_mapInfo.resolution;
 
@@ -136,7 +136,7 @@ void GridMap2D::setMap(const cv::Mat& binaryMap){
 void GridMap2D::inflateMap(double inflationRadius){
   m_binaryMap = (m_distMap > inflationRadius );
   // recompute distance map with new binary map:
-  cv::distanceTransform(m_binaryMap, m_distMap, CV_DIST_L2, CV_DIST_MASK_PRECISE);
+  cv::distanceTransform(m_binaryMap, m_distMap, cv::DistanceTypes::DIST_L2, cv::DistanceTransformMasks::DIST_MASK_PRECISE);
   m_distMap = m_distMap * m_mapInfo.resolution;
 }
 


### PR DESCRIPTION
Renamed global namespace symbols which have now been encapsulated into
CV enumeration classes.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>